### PR TITLE
Improve build instructions for osslsigncode, fixes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ removal and extraction.
 
 ## BUILDING
 
-Ths build technique works on Linux and macOS, if you have the necessary tools installed:
+This build technique works on Linux and macOS, if you have the necessary tools installed:
 ```
   ./autogen.sh
   ./configure
@@ -36,11 +36,10 @@ Ths build technique works on Linux and macOS, if you have the necessary tools in
 ```
 
 * On Linux, (tested on Debian/Ubuntu) you may need `sudo apt-get update && sudo apt-get install build-essential autoconf libtool libssl-dev python3-pkgconfig libcurl4-gnutls-dev`
-* On macOS with Homebrew, you probably need to do these tings before autogen.sh and configure:
+* On macOS with Homebrew, you probably need to do these things before autogen.sh and configure:
 ```
   brew install openssl@1.1 automake pkg-config libtool
-  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
-  export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+  export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 ```
 
 ## USAGE

--- a/README.md
+++ b/README.md
@@ -25,13 +25,22 @@ valid signature for a CAB file containing Java files. It supports getting
 the timestamp through a proxy as well. It also supports signature verification,
 removal and extraction.
 
-## INSTALLATION
+## BUILDING
 
-The usual way:
+Ths build technique works on Linux and macOS, if you have the necessary tools installed:
 ```
+  ./autogen.sh
   ./configure
   make
   make install
+```
+
+* On Linux, (tested on Debian/Ubuntu) you may need `sudo apt-get update && sudo apt-get install build-essential autoconf libtool libssl-dev python3-pkgconfig libcurl4-gnutls-dev`
+* On macOS with Homebrew, you probably need to do these tings before autogen.sh and configure:
+```
+  brew install openssl@1.1 automake pkg-config libtool
+  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+  export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
 ```
 
 ## USAGE


### PR DESCRIPTION
Per #12, this adds build instructions for Linux (Debian/Ubuntu biased) and macOS. You had suggested replacing the environment exports with pkg-config, but that doesn't accomplish putting openssl 1.1 into scope, pretty sure you have to do that. 