### PR TITLE
add option to override non-trusted time in signature

### DIFF
--- a/osslsigncode.c
+++ b/osslsigncode.c
@@ -469,10 +469,11 @@ static size_t asn1_simple_hdr_len(const unsigned char *p, size_t len)
 }
 
 /*
- * Add a custom timestamp to the PKCS7 structure to prevent OpenSSL adding
- * the _current_ time. This allows to create a deterministic signature when
- * no trusted timestamp server was specified, making osslsigncode behaviour
- * similar to signtool.exe.
+ * Add a custom, non-trusted time to the PKCS7 structure to prevent OpenSSL
+ * adding the _current_ time. This allows to create a deterministic signature
+ * when no trusted timestamp server was specified, making osslsigncode
+ * behaviour closer to signtool.exe (which doesn't include any non-trusted
+ * time in this case.)
  */
 static int pkcs7_add_custom_time(PKCS7_SIGNER_INFO *si, time_t customtimeutc)
 {


### PR DESCRIPTION
By default the non-trusted time embedded in the signature is the current time of the machine. This means that adding a signature prevents from creating reproducible/deterministic binaries.
    
This patch resolves that by introducing the `-st <unix-time>` option where a custom time can be supplied and which will be used in the signature. By using a point in time bound to the package (e.g. release date or timestamp of a specific file in the source package – or just 0 to suppress the current time), it makes it possible to create signed binaries with reproducible/deterministic, IOW identical signatures, regardless of when the build was done. It also makes osslsigncode behaviour closer to `signtool.exe`, which by default creates deterministic signatures (by include no non-trusted time at all.)
    
The patch has been used live for the last year to build `curl-for-win` binaries:
      https://github.com/curl/curl-for-win/blob/master/osslsigncode.patch
    
It also resolves this `osslsigncode` bug:
      https://sourceforge.net/p/osslsigncode/bugs/8/#a59a