### PR TITLE
Fix timestamp and CRL verification

### DIFF
--- a/tests/certs/makecerts.sh
+++ b/tests/certs/makecerts.sh
@@ -45,7 +45,7 @@ make_certs() {
     script_path=$(pwd)
     OPENSSL=openssl
     CONF="${script_path}/openssltest.cnf"
-    $OPENSSL req -config $CONF -new -x509 -days 1800 -key demoCA/CA.key -out tmp/CACert.pem \
+    $OPENSSL req -config $CONF -new -x509 -days 3600 -key demoCA/CA.key -out tmp/CACert.pem \
         -subj "/C=PL/O=osslsigncode/OU=Root CA/CN=CA/emailAddress=CA@example.com" \
         2>> "makecerts.log" 1>&2'
   test_result $?

--- a/tests/certs/openssltest.cnf
+++ b/tests/certs/openssltest.cnf
@@ -19,7 +19,7 @@ x509_extensions                 = usr_cert
 private_key                     = $dir/demoCA/CA.key
 certificate                     = $dir/tmp/CACert.pem
 default_startdate               = 180101000000Z
-default_enddate                 = 280101000000Z
+default_enddate                 = 210101000000Z
 
 [ req ]
 encrypt_key                     = no


### PR DESCRIPTION
- new option `-timestamp_expiration` to verify a finite lifetime of the TSA certificate
- verify timestamp against the time of its creation by default
- new option `-crluntrusted`  to check the appropriate CRL to verify that the TSA's certificate is still valid
- verify CRLs against the current time
- ignore expired signer certificate for CRL validation
- print CRLs distribution points
