### PR TITLE
Read crypto parameters

### DIFF
--- a/osslsigncode.c
+++ b/osslsigncode.c
@@ -4839,10 +4839,8 @@ static char *find_pvk_key(GLOBAL_OPTIONS *options)
 			)
 		return NULL; /* FAILED */
 	btmp = BIO_new_file(options->keyfile, "rb");
-	if (!btmp) {
-		printf("Failed to read private key file: %s\n", options->keyfile);
+	if (!btmp)
 		return NULL; /* FAILED */
-	}
 	magic[0] = 0x00;
 	BIO_read(btmp, magic, 4);
 	if (!memcmp(magic, pvkhdr, 4)) {
@@ -5026,6 +5024,8 @@ static void free_crypto_params(CRYPTO_PARAMS *cparams)
 	cparams->certs = NULL;
 	sk_X509_pop_free(cparams->xcerts, X509_free);
 	cparams->xcerts = NULL;
+	sk_X509_CRL_pop_free(cparams->crls, X509_CRL_free);
+	cparams->crls = NULL;
 }
 
 static void free_options(GLOBAL_OPTIONS *options)

--- a/tests/certs/makecerts.sh
+++ b/tests/certs/makecerts.sh
@@ -20,7 +20,7 @@ make_certs() {
   mkdir "tmp/"
 
 # OpenSSL settings
-  CONF="${script_path}/openssltest.cnf"
+  CONF="${script_path}/openssl_intermediate.cnf"
   TEMP_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
   if test -n "$1"
     then
@@ -44,11 +44,32 @@ make_certs() {
   TZ=GMT faketime -f '@2017-01-01 00:00:00' /bin/bash -c '
     script_path=$(pwd)
     OPENSSL=openssl
-    CONF="${script_path}/openssltest.cnf"
+    CONF="${script_path}/openssl_root.cnf"
     $OPENSSL req -config $CONF -new -x509 -days 3600 -key demoCA/CA.key -out tmp/CACert.pem \
-        -subj "/C=PL/O=osslsigncode/OU=Root CA/CN=CA/emailAddress=CA@example.com" \
+        -subj "/C=PL/O=osslsigncode/OU=Certification Authority/CN=Root CA" \
         2>> "makecerts.log" 1>&2'
   test_result $?
+
+  printf "\nGenerate intermediate CA certificate\n" >> "makecerts.log"
+  $OPENSSL genrsa -out demoCA/intermediate.key \
+        2>> "makecerts.log" 1>&2
+    TZ=GMT faketime -f '@2017-01-01 00:00:00' /bin/bash -c '
+    script_path=$(pwd)
+    OPENSSL=openssl
+    CONF="${script_path}/openssl_intermediate.cnf"
+    $OPENSSL req -config $CONF -new -key demoCA/intermediate.key -out demoCA/intermediate.csr \
+        -subj "/C=PL/O=osslsigncode/OU=Certification Authority/CN=Intermediate CA" \
+        2>> "makecerts.log" 1>&2'
+  test_result $?
+  TZ=GMT faketime -f '@2017-01-01 00:00:00' /bin/bash -c '
+    script_path=$(pwd)
+    OPENSSL=openssl
+    CONF="${script_path}/openssl_root.cnf"
+    $OPENSSL ca -config $CONF -batch -in demoCA/intermediate.csr -out demoCA/intermediate.cer \
+        2>> "makecerts.log" 1>&2'
+  test_result $?
+  $OPENSSL x509 -in demoCA/intermediate.cer -out tmp/intermediate.pem \
+      2>> "makecerts.log" 1>&2
 
   printf "\nGenerate private RSA encrypted key\n" >> "makecerts.log"
   $OPENSSL genrsa -des3 -out demoCA/private.key -passout pass:$password \
@@ -63,7 +84,7 @@ make_certs() {
 
   printf "\nGenerate a certificate to revoke\n" >> "makecerts.log"
   $OPENSSL req -config $CONF -new -key demoCA/private.key -passin pass:$password -out demoCA/revoked.csr \
-      -subj "/C=PL/O=osslsigncode/OU=CA/CN=revoked/emailAddress=revoked@example.com" \
+      -subj "/C=PL/O=osslsigncode/OU=CSP/CN=Revoked/emailAddress=osslsigncode@example.com" \
       2>> "makecerts.log" 1>&2
   $OPENSSL ca -config $CONF -batch -in demoCA/revoked.csr -out demoCA/revoked.cer \
       2>> "makecerts.log" 1>&2
@@ -71,16 +92,24 @@ make_certs() {
       2>> "makecerts.log" 1>&2
 
   printf "\nRevoke above certificate\n" >> "makecerts.log"
-  $OPENSSL ca -config $CONF -revoke demoCA/1000.pem \
+  $OPENSSL ca -config $CONF -revoke demoCA/1001.pem \
       2>> "makecerts.log" 1>&2
+
+  printf "\nAttach intermediate certificate to revoked certificate\n" >> "makecerts.log"
+  cat tmp/intermediate.pem >> tmp/revoked.pem
 
   printf "\nGenerate CRL file\n" >> "makecerts.log"
   TZ=GMT faketime -f '@2019-01-01 00:00:00' /bin/bash -c '
     script_path=$(pwd)
     OPENSSL=openssl
-    CONF="${script_path}/openssltest.cnf"
+    CONF="${script_path}/openssl_intermediate.cnf"
     $OPENSSL ca -config $CONF -gencrl -crldays 8766 -out tmp/CACertCRL.pem \
         2>> "makecerts.log" 1>&2'
+
+  printf "\nConvert revoked certificate to SPC format\n" >> "makecerts.log"
+  $OPENSSL crl2pkcs7 -in tmp/CACertCRL.pem -certfile tmp/revoked.pem -outform DER -out tmp/revoked.spc \
+      2>> "makecerts.log" 1>&2
+  test_result $?
 
   printf "\nGenerate CSP Cross-Certificate\n" >> "makecerts.log"
   $OPENSSL genrsa -out demoCA/cross.key \
@@ -88,15 +117,15 @@ make_certs() {
   TZ=GMT faketime -f '@2018-01-01 00:00:00' /bin/bash -c '
     script_path=$(pwd)
     OPENSSL=openssl
-   CONF="${script_path}/openssltest.cnf"
-   $OPENSSL req -config $CONF -new -x509 -days 900 -key demoCA/cross.key -out tmp/crosscert.pem \
-       -subj "/C=PL/O=osslsigncode/OU=CSP/CN=crosscert/emailAddress=CA@example.com" \
+    CONF="${script_path}/openssl_intermediate.cnf"
+    $OPENSSL req -config $CONF -new -x509 -days 900 -key demoCA/cross.key -out tmp/crosscert.pem \
+       -subj "/C=PL/O=osslsigncode/OU=CSP/CN=crosscert/emailAddress=osslsigncode@example.com" \
        2>> "makecerts.log" 1>&2'
   test_result $?
 
   printf "\nGenerate code signing certificate\n" >> "makecerts.log"
   $OPENSSL req -config $CONF -new -key demoCA/private.key -passin pass:$password -out demoCA/cert.csr \
-      -subj "/C=PL/ST=Mazovia Province/L=Warsaw/O=osslsigncode/OU=CA/CN=localhost/emailAddress=osslsigncode@example.com" \
+      -subj "/C=PL/ST=Mazovia Province/L=Warsaw/O=osslsigncode/OU=CSP/CN=Certificate/emailAddress=osslsigncode@example.com" \
       2>> "makecerts.log" 1>&2
   test_result $?
   $OPENSSL ca -config $CONF -batch -in demoCA/cert.csr -out demoCA/cert.cer \
@@ -111,10 +140,18 @@ make_certs() {
       2>> "makecerts.log" 1>&2
   test_result $?
 
+  printf "\nConvert the key to PVK format\n" >> "makecerts.log"
+  $OPENSSL rsa -in tmp/key.pem -outform PVK -out tmp/key.pvk -pvk-none \
+      2>> "makecerts.log" 1>&2
+  test_result $?
+
   printf "\nConvert the certificate to DER format\n" >> "makecerts.log"
   $OPENSSL x509 -in tmp/cert.pem -outform DER -out tmp/cert.der \
       2>> "makecerts.log" 1>&2
   test_result $?
+
+  printf "\nAttach intermediate certificate to code signing certificate\n" >> "makecerts.log"
+  cat tmp/intermediate.pem >> tmp/cert.pem
 
   printf "\nConvert the certificate to SPC format\n" >> "makecerts.log"
   $OPENSSL crl2pkcs7 -nocrl -certfile tmp/cert.pem -outform DER -out tmp/cert.spc \
@@ -128,7 +165,7 @@ make_certs() {
 
   printf "\nGenerate expired certificate\n" >> "makecerts.log"
   $OPENSSL req -config $CONF -new -key demoCA/private.key -passin pass:$password -out demoCA/expired.csr \
-      -subj "/C=PL/ST=Mazovia Province/L=Warsaw/O=osslsigncode/OU=CA/CN=expired/emailAddress=expired@example.com" \
+      -subj "/C=PL/ST=Mazovia Province/L=Warsaw/O=osslsigncode/OU=CSP/CN=Expired/emailAddress=osslsigncode@example.com" \
       2>> "makecerts.log" 1>&2
   test_result $?
   $OPENSSL ca -config $CONF -enddate "190101000000Z" -batch -in demoCA/expired.csr -out demoCA/expired.cer \
@@ -138,10 +175,14 @@ make_certs() {
       2>> "makecerts.log" 1>&2
   test_result $?
 
+  printf "\nAttach intermediate certificate to expired certificate\n" >> "makecerts.log"
+  cat tmp/intermediate.pem >> tmp/expired.pem
+
 # copy new files
-  if test -s tmp/CACert.pem -a -s tmp/crosscert.pem -a -s tmp/expired.pem -a -s tmp/cert.pem \
-    -a -s tmp/CACertCRL.pem -a -s tmp/revoked.pem -a -s tmp/key.pem -a -s tmp/keyp.pem \
-    -a -s tmp/key.der -a -s tmp/cert.der -a -s tmp/cert.spc -a -s tmp/cert.p12
+  if test -s tmp/intermediate.pem -a -s tmp/CACert.pem -a -s tmp/CACertCRL.pem \
+      -a -s tmp/key.pem -a -s tmp/keyp.pem -a -s tmp/key.der -a -s tmp/key.pvk \
+      -a -s tmp/cert.pem -a -s tmp/cert.p12 -a -s tmp/cert.der -a -s tmp/cert.spc \
+      -a -s tmp/crosscert.pem -a -s tmp/expired.pem -a -s tmp/revoked.pem -a -s tmp/revoked.spc
   then
     cp tmp/* ./
     printf "%s\n" "keys & certificates successfully generated"

--- a/tests/certs/openssl_intermediate.cnf
+++ b/tests/certs/openssl_intermediate.cnf
@@ -1,0 +1,61 @@
+# OpenSSL intermediate CA configuration file
+
+[ ca ]
+default_ca                      = CA_default
+
+[ CA_default ]
+# Directory and file locations
+dir                             = .
+certs                           = $dir/demoCA
+crl_dir                         = $dir/demoCA
+new_certs_dir                   = $dir/demoCA
+database                        = $dir/demoCA/index.txt
+serial                          = $dir/demoCA/serial
+private_key                     = $dir/demoCA/intermediate.key
+certificate                     = $dir/tmp/intermediate.pem
+crl_extensions                  = crl_ext
+default_md                      = sha256
+preserve                        = no
+policy                          = policy_loose
+default_startdate               = 180101000000Z
+default_enddate                 = 210101000000Z
+
+[ req ]
+# Options for the `req` tool
+encrypt_key                     = no
+default_bits                    = 2048
+default_md                      = sha256
+string_mask                     = utf8only
+distinguished_name              = req_distinguished_name
+x509_extensions                 = usr_extensions
+
+[ crl_ext ]
+# Extension for CRLs
+authorityKeyIdentifier          = keyid:always
+
+[ usr_extensions ]
+# Extension to add when the -x509 option is used
+basicConstraints                = CA:FALSE
+subjectKeyIdentifier            = hash
+authorityKeyIdentifier          = keyid, issuer
+extendedKeyUsage                = codeSigning
+
+[ policy_loose ]
+# Allow the intermediate CA to sign a more diverse range of certificates.
+# See the POLICY FORMAT section of the `ca` man page.
+countryName                     = optional
+stateOrProvinceName             = optional
+localityName                    = optional
+organizationName                = optional
+organizationalUnitName          = optional
+commonName                      = supplied
+emailAddress                    = optional
+
+[ req_distinguished_name ]
+countryName                     = Country Name (2 letter code)
+stateOrProvinceName             = State or Province Name
+localityName                    = Locality Name
+0.organizationName              = Organization Name
+organizationalUnitName          = Organizational Unit Name
+commonName                      = Common Name
+emailAddress                    = Email Address

--- a/tests/certs/openssl_root.cnf
+++ b/tests/certs/openssl_root.cnf
@@ -1,0 +1,61 @@
+# OpenSSL root CA configuration file
+
+[ ca ]
+default_ca                      = CA_default
+
+[ CA_default ]
+# Directory and file locations.
+dir                             = .
+certs                           = $dir/demoCA
+crl_dir                         = $dir/demoCA
+new_certs_dir                   = $dir/demoCA
+database                        = $dir/demoCA/index.txt
+serial                          = $dir/demoCA/serial
+private_key                     = $dir/demoCA/CA.key
+certificate                     = $dir/tmp/CACert.pem
+crl_extensions                  = crl_ext
+default_md                      = sha256
+preserve                        = no
+policy                          = policy_match
+default_startdate               = 180101000000Z
+default_enddate                 = 260101000000Z
+x509_extensions                 = v3_intermediate_ca
+
+[ req ]
+# Options for the `req` tool
+encrypt_key                     = no
+default_bits                    = 2048
+default_md                      = sha256
+string_mask                     = utf8only
+x509_extensions                 = ca_extensions
+distinguished_name              = req_distinguished_name
+
+[ ca_extensions ]
+# Extension to add when the -x509 option is used
+basicConstraints                = critical, CA:true
+subjectKeyIdentifier            = hash
+authorityKeyIdentifier          = keyid:always,issuer
+keyUsage                        = critical, digitalSignature, cRLSign, keyCertSign
+
+[ v3_intermediate_ca ]
+# Extensions for a typical intermediate CA (`man x509v3_config`)
+basicConstraints                = critical, CA:true, pathlen:0
+subjectKeyIdentifier            = hash
+authorityKeyIdentifier          = keyid:always,issuer
+keyUsage                        = critical, digitalSignature, cRLSign, keyCertSign
+
+[ policy_match ]
+countryName                     = match
+organizationName                = match
+organizationalUnitName          = optional
+commonName                      = supplied
+emailAddress                    = optional
+
+[ req_distinguished_name ]
+countryName                     = Country Name (2 letter code)
+stateOrProvinceName             = State or Province Name
+localityName                    = Locality Name
+0.organizationName              = Organization Name
+organizationalUnitName          = Organizational Unit Name
+commonName                      = Common Name
+emailAddress                    = Email Address

--- a/tests/recipes/04_sign_spc_pvk
+++ b/tests/recipes/04_sign_spc_pvk
@@ -1,18 +1,18 @@
 #!/bin/sh
 # Sign a PE/CAB/MSI file with the certificate file in the SPC format
-# and the private key file in the PEM format.
+# and the private key file in the Microsoft Private Key (PVK) format.
 
 . $(dirname $0)/../test_library
 script_path=$(pwd)
 
 # PE file
-test_name="041. Sign a PE file a SPC certificate file"
+test_name="041. Sign a PE file a SPC certificate file and a PVK private key file"
 printf "\n%s\n" "$test_name"
 if test -s "test.exe"
   then
     ../../osslsigncode sign -h sha256 \
         -st "1556668800" \
-        -certs "${script_path}/../certs/cert.spc" -key "${script_path}/../certs/keyp.pem" \
+        -spc "${script_path}/../certs/cert.spc" -key "${script_path}/../certs/key.pvk" \
         -pass passme \
         -in "test.exe" -out "test_041.exe"
     verify_signature "$?" "041" "exe" "success" "@2019-09-01 12:00:00" \
@@ -23,13 +23,13 @@ if test -s "test.exe"
   fi
 
 # CAB file
-test_name="042. Sign a CAB file a SPC certificate file"
+test_name="042. Sign a CAB file a SPC certificate file and a PVK private key file"
 printf "\n%s\n" "$test_name"
 if test -s "test.ex_"
   then
     ../../osslsigncode sign -h sha256 \
         -st "1556668800" \
-        -certs "${script_path}/../certs/cert.spc" -key "${script_path}/../certs/keyp.pem" \
+        -spc "${script_path}/../certs/cert.spc" -key "${script_path}/../certs/key.pvk" \
         -pass passme \
         -in "test.ex_" -out "test_042.ex_"
     verify_signature "$?" "042" "ex_" "success" "@2019-09-01 12:00:00" \
@@ -40,13 +40,13 @@ if test -s "test.ex_"
   fi
 
 # MSI file
-test_name="043. Sign a MSI file a SPC certificate file"
+test_name="043. Sign a MSI file a SPC certificate file and a PVK private key file"
 printf "\n%s\n" "$test_name"
 if test -s "sample.msi"
   then
     ../../osslsigncode sign -h sha256 \
         -st "1556668800" \
-        -certs "${script_path}/../certs/cert.spc" -key "${script_path}/../certs/keyp.pem" \
+        -spc "${script_path}/../certs/cert.spc" -key "${script_path}/../certs/key.pvk" \
         -pass passme \
         -in "sample.msi" -out "test_043.msi"
     verify_signature "$?" "043" "msi" "success" "@2019-09-01 12:00:00" \


### PR DESCRIPTION
- new option `-pkcs11cert` identifies a certificate in the token
- additional CRLs (supplied as part of a PKCS#7 structure) support
- find the signer's certificate in the certificate chain
- improve maketest - add intermediate CA cert