### PR TITLE
Allow signing in place

### DIFF
--- a/osslsigncode.c
+++ b/osslsigncode.c
@@ -150,11 +150,7 @@ typedef unsigned char u_char;
 #define PROVIDE_ASKPASS 1
 #endif
 
-#ifdef _WIN32
 #define FILE_CREATE_MODE "w+b"
-#else
-#define FILE_CREATE_MODE "w+bx"
-#endif
 
 /* Microsoft OID Authenticode */
 #define SPC_INDIRECT_DATA_OBJID      "1.3.6.1.4.1.311.2.1.4"


### PR DESCRIPTION
Forgive the unrequested PR, if this behavior is intentional, feel free to close.

In the unmaintained 2.0 version, `osslsigncode` supported signing in place. But, in the 2.1 version, this does not work. I belive because `FILE_CREATE_MODE "w+bx"` So, the `+` causes it to fail if the file exists.

As most `.exe` files need to be signed multiple ties (for sha1 and sha256) this creates a cumbersome mv; sign; rm cycle.

This PR removes the `x` from `FILE_CREATE_MODE`

```shell
dover:launcher seph$ /usr/local/Cellar/osslsigncode/2.0_1/bin/osslsigncode -in /tmp/test.exe -out /tmp/test.exe -h sha1  -pkcs12 "${P12}"  -pass "${AUTHENTICODE_PASSPHRASE}"
Succeeded

dover:launcher seph$ /usr/local/Cellar/osslsigncode/2.1/bin/osslsigncode sign -in /tmp/test.exe -out /tmp/test.exe -h sha1  -pkcs12 "${P12}"  -pass "${AUTHENTICODE_PASSPHRASE}"
Failed to create file: /tmp/test.exe
4530218432:error:02001011:system library:fopen:File exists:crypto/bio/bss_file.c:69:fopen('/tmp/test.exe','w+bx')
4530218432:error:2006D002:BIO routines:BIO_new_file:system lib:crypto/bio/bss_file.c:78:
Failed
```