### PR TITLE
update documentation for timestamp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ or if you want to add a timestamp as well:
 ```
   osslsigncode sign -certs <cert-file> -key <key-file> \
     -n "Your Application" -i http://www.yourwebsite.com/ \
-    -t http://timestamp.verisign.com/scripts/timstamp.dll \
+    -t http://timestamp.digicert.com \
     -in yourapp.exe -out yourapp-signed.exe
 ```
 You can use a certificate and key stored in a PKCS#12 container:

--- a/README.unauthblob.md
+++ b/README.unauthblob.md
@@ -14,7 +14,7 @@ osslsigncode sign -addUnauthenticatedBlob -pkcs12 yourcert.pfx -pass your_passwo
 
 ```
 # Example 2. Timestamp and add blob to signed file 
-osslsigncode.exe add -addUnauthenticatedBlob -t http://timestamp.verisign.com/scripts/timstamp.dll -in your_signed_file.exe -out out.exe
+osslsigncode.exe add -addUnauthenticatedBlob -t http://timestamp.digicert.com -in your_signed_file.exe -out out.exe
 ```
 
 ```


### PR DESCRIPTION
- verisign timestamp server is no longer in service
   update docs to point to alternative service

fixes #71 