### PR TITLE
fix crl nullptr crash in read_certfile

### DIFF
--- a/osslsigncode.c
+++ b/osslsigncode.c
@@ -4819,7 +4819,8 @@ static int read_certfile(GLOBAL_OPTIONS *options, CRYPTO_PARAMS *cparams)
 		cparams->certs = X509_chain_up_ref(p7->d.sign->cert);
 
 		/* additional CRLs may be supplied as part of a PKCS#7 signed data structure */
-		cparams->crls = X509_CRL_chain_up_ref(p7->d.sign->crl);
+		if (p7->d.sign->crl)
+			cparams->crls = X509_CRL_chain_up_ref(p7->d.sign->crl);
 		PKCS7_free(p7);
 	}
 


### PR DESCRIPTION
I tested with an old expired production cert, decodes to `p7->d.sign->crl == NULL`. I can't attach the cert here but tell me if you need more info.