### PR TITLE
missing autoconf for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This build technique works on Linux and macOS, if you have the necessary tools i
 * On Linux, (tested on Debian/Ubuntu) you may need `sudo apt-get update && sudo apt-get install build-essential autoconf libtool libssl-dev python3-pkgconfig libcurl4-gnutls-dev`
 * On macOS with Homebrew, you probably need to do these things before autogen.sh and configure:
 ```
-  brew install openssl@1.1 automake pkg-config libtool
+  brew install openssl@1.1 autoconf automake pkg-config libtool
   export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 ```
 


### PR DESCRIPTION
Error when execute % ./autogen.sh because of missing autocanf package

```
Preparing the osslsigncode build system...please wait

ERROR:  Unable to locate GNU Autoconf.

ERROR:  To prepare the osslsigncode build system from scratch,
        at least version 2.52 of GNU Autoconf must be installed.

autogen.sh does not need to be run on the same machine that will
run configure or make.  Either the GNU Autotools will need to be installed
or upgraded on this system, or autogen.sh must be run on the source
code on another system and then transferred to here. -- Cheers!
```