### PR TITLE
Return failure codes from make_tests

### DIFF
--- a/tests/testall.sh
+++ b/tests/testall.sh
@@ -25,8 +25,9 @@ make_tests() {
       fail=$(grep -c "Test failed" "results.log")
       printf "%s\n" "testall.sh finished"
       printf "%s\n" "summary: success $count, skip $skip, fail $fail"
+      return $fail
     else # no test was done
-      result=1
+      return 1
     fi
 }
 


### PR DESCRIPTION
make_tests sets result, but the code calling it expects it to set its
exit code instead ($?). This changes make_tests to return 1 instead of
setting result to 1; in addition, it will return the number of failed
tests, which allows using the test script as a whole in jobs which
expect a global failure indication.

Signed-off-by: Stephen Kitt <steve@sk2.org>