### PR TITLE
Don't '#include <windows.h>' on Cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@ AC_PREREQ(2.60)
 AC_INIT([osslsigncode], [2.4.0-dev], [Michal.Trojnara@stunnel.org])
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_HEADERS([config.h])
+AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE
 
 AC_CONFIG_SRCDIR([osslsigncode.c])
@@ -69,11 +70,18 @@ AC_CHECK_HEADERS(
 	)],
 	[have_mmap=no]
 )
+
+case "${host_os}" in
+  cygwin*)
+    ;;
+  *)
 AC_CHECK_HEADERS(
 	[windows.h],
 	[],
 	[have_MapViewOfFile=no]
 )
+esac
+
 AS_IF([test "x$have_mmap$have_MapViewOfFile" = "xnono"],
 	[AC_MSG_ERROR([Need file mapping function to buid.])])
 


### PR DESCRIPTION
On Cygwin, don't '#include <windows.h>', so WIN32 isn't defined, so we
don't end up trying to use various MSVC functions, which don't exist in
our C runtime library.

The whole point of the Cygwin C runtime library is to try to look like
POSIX, so we always want the POSIX code in those pre-processor
conditionals.