### PR TITLE
Fix asn1_get_time_t timezone offset

### DIFF
--- a/osslsigncode.c
+++ b/osslsigncode.c
@@ -2095,7 +2095,11 @@ static time_t asn1_get_time_t(const ASN1_TIME *s)
 		return INVALID_TIME;
 	}
 	if (ASN1_TIME_to_tm(s, &tm)) {
-		return mktime(&tm);
+#ifdef _WIN32
+		return _mkgmtime(&tm);
+#else
+		return timegm(&tm);
+#endif
 	} else {
 		return INVALID_TIME;
 	}


### PR DESCRIPTION
mktime takes an input in local time, but what we have is UTC.  timegm does the right thing but is a nonstandard GNU and BSD extension.  I'm not sure if this is acceptable?

I hit an issue where my local time zone is CET (UTC+1), the timestamp server returns something like `230208140333Z`, and osslsigncode says "Signing time: Feb  8 13:03:33 2023 GMT", an hour off.  It also seems to cause verification problems if e.g. the CA or signing cert is newly created because set_store_time is called with a time_t that can be in the future.