### PR TITLE
bugfix: command sign -nest -t[s], must timestamped new (created) sign…

### DIFF
--- a/cab.c
+++ b/cab.c
@@ -493,16 +493,8 @@ static PKCS7 *cab_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
             return NULL; /* FAILED */
         }
     }
-    if (ctx->options->nest) {
-        if (!cursig_set_nested(cursig, p7, ctx)) {
-            printf("Unable to append the nested signature to the current signature\n");
-            PKCS7_free(p7);
-            PKCS7_free(cursig);
-            return NULL; /* FAILED */
-        }
-        PKCS7_free(p7);
-        return cursig;
-    }
+    if (ctx->options->nest)
+        ctx->options->prevsig = cursig;
     return p7;
 }
 

--- a/msi.c
+++ b/msi.c
@@ -660,17 +660,9 @@ static PKCS7 *msi_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
             return NULL; /* FAILED */
         }
     }
-    if (ctx->options->nest) {
-        if (!cursig_set_nested(cursig, p7, ctx)) {
-            printf("Unable to append the nested signature to the current signature\n");
-            PKCS7_free(p7);
-            PKCS7_free(cursig);
-            return NULL; /* FAILED */
-        }
-        PKCS7_free(p7);
-        return cursig;
-    }
-    return p7;
+    if (ctx->options->nest)
+        ctx->options->prevsig = cursig;
+        return p7;
 }
 
 /*

--- a/msi.c
+++ b/msi.c
@@ -662,7 +662,7 @@ static PKCS7 *msi_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
     }
     if (ctx->options->nest)
         ctx->options->prevsig = cursig;
-        return p7;
+    return p7;
 }
 
 /*

--- a/osslsigncode.c
+++ b/osslsigncode.c
@@ -2261,6 +2261,9 @@ static void free_options(GLOBAL_OPTIONS *options)
     /* If X509 structure is NULL nothing is done */
     X509_free(options->cert);
     options->cert = NULL;
+    /* If PKCS7 structure is NULL nothing is done */
+    PKCS7_free(options->prevsig);
+    options->prevsig = NULL;
     /* Free up all elements of sk structure and sk itself */
     sk_X509_pop_free(options->certs, X509_free);
     options->certs = NULL;
@@ -3673,6 +3676,13 @@ int main(int argc, char **argv)
     if (ret) {
         PKCS7_free(p7);
         DO_EXIT_0("Unable to set unauthenticated attributes\n");
+    }
+    if (options.prevsig) {
+        if (!cursig_set_nested(options.prevsig, p7, ctx))
+            DO_EXIT_0("Unable to append the nested signature to the current signature\n");
+        PKCS7_free(p7);
+        p7 = options.prevsig;
+        options.prevsig = NULL;
     }
     if (ctx->format->append_pkcs7) {
         ret = ctx->format->append_pkcs7(ctx, outdata, p7);

--- a/osslsigncode.h
+++ b/osslsigncode.h
@@ -277,6 +277,7 @@ typedef struct {
     STACK_OF(X509_CRL) *crls;
     cmd_type_t cmd;
     char *indata;
+    PKCS7 *prevsig;
 } GLOBAL_OPTIONS;
 
 /*

--- a/pe.c
+++ b/pe.c
@@ -421,7 +421,7 @@ static PKCS7 *pe_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
         }
         if (ctx->options->cmd == CMD_ADD)
             p7 = cursig;
-    } 
+    }
     if (ctx->pe_ctx->sigpos > 0) {
         /* Strip current signature */
         ctx->pe_ctx->fileend = ctx->pe_ctx->sigpos;
@@ -451,16 +451,8 @@ static PKCS7 *pe_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
             return NULL; /* FAILED */
         }
     }
-    if (ctx->options->nest) {
-        if (!cursig_set_nested(cursig, p7, ctx)) {
-            printf("Unable to append the nested signature to the current signature\n");
-            PKCS7_free(p7);
-            PKCS7_free(cursig);
-            return NULL; /* FAILED */
-        }
-        PKCS7_free(p7);
-        return cursig;
-    }
+    if (ctx->options->nest)
+        ctx->options->prevsig = cursig;
     return p7;
 }
 


### PR DESCRIPTION
…ature, nor current (first in chain)!