### PR TITLE
Fix construction of signed CAB header

### DIFF
--- a/cab.c
+++ b/cab.c
@@ -900,6 +900,7 @@ static int cab_add_header(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
      */
     nfolders = GET_UINT16_LE(ctx->options->indata + 26);
     while (nfolders) {
+        tmp = GET_UINT32_LE(ctx->options->indata + i);
         tmp += 24;
         PUT_UINT32_LE(tmp, buf);
         BIO_write(hash, buf, 4);


### PR DESCRIPTION
Commit 0f51a06 ("Separate common and format-dependent functions") performed a substantial amount of refactoring.  Within the CFFOLDER header construction loop in cab_add_header(), the line

   tmp = GET_UINT32_LE(indata + i);

seems to have been accidentally deleted, instead of being refactored to become

   tmp = GET_UINT32_LE(ctx->options->indata + i);

with the result that adding a signature to a .cab file will currently produce an invalid .cab file.

Fix by adding back in the missing line of code.

Fixes: #289