### PR TITLE
Add missing dependencies for install in fresh ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We highly recommend downloading a [release tarball](https://github.com/mtrojnar/
 
 * Install prerequisites on a Debian-based distributions, such as Ubuntu:
 ```
-  sudo apt update && sudo apt install cmake libssl-dev libcurl4-openssl-dev
+  sudo apt update && sudo apt install cmake libssl-dev libcurl4-openssl-dev zlib1g-dev python3
 ```
 * Install prerequisites on macOS with Homebrew:
 ```


### PR DESCRIPTION
hi, when I was trying to install osslsigncode into a fresh ubuntu docker image, I was getting CMake errors complaining about not finding ZLib and Python3, so I suggest adding those to the `apt install` command in the instructions.

FWIW, here is the dockerfile I made:
```
FROM ubuntu:22.04

RUN apt-get update
RUN apt-get install -y wget

WORKDIR /app
RUN wget https://github.com/mtrojnar/osslsigncode/archive/refs/tags/2.7.tar.gz
RUN tar -xf 2.7.tar.gz

RUN apt update && apt -y install cmake libssl-dev libcurl4-openssl-dev
RUN apt -y install zlib1g-dev python3

WORKDIR /app/osslsigncode-2.7
RUN mkdir build && cd build && cmake -S ..

WORKDIR /app/osslsigncode-2.7/build
RUN cmake --build .
# RUN ctest -C Release
RUN cmake --install .
RUN cmake --build . --target package_source

WORKDIR /app
```