### PR TITLE
Index option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ### 2.8 (unreleased)
 
+- fixed setting unauthenticated attributes (Countersignature,
+  Unauthenticated Data Blob) in a nested signature
+- added support for verifying the signature at a certain position ("-index" option)
+- added support for adding unauthenticated attributes to the signature
+  at a certain position ("-index" option)
 - added CAT file verification and listing each member of the CAT file
   by using the "-verbose" option
 - added new command "extract-data" to extract a PKCS#7 data content to be signed

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - added CAT file verification and listing each member of the CAT file
   by using the "-verbose" option
 - added new command "extract-data" to extract a PKCS#7 data content to be signed
+- PKCS9_SEQUENCE_NUMBER authenticated attribute support
 
 ### 2.7 (2023.09.19)
 

--- a/cab.c
+++ b/cab.c
@@ -49,8 +49,10 @@ static int cab_check_file(FILE_FORMAT_CTX *ctx, int detached);
 static u_char *cab_digest_calc(FILE_FORMAT_CTX *ctx, const EVP_MD *md);
 static int cab_verify_digests(FILE_FORMAT_CTX *ctx, PKCS7 *p7);
 static PKCS7 *cab_pkcs7_extract(FILE_FORMAT_CTX *ctx);
+static PKCS7 *cab_pkcs7_extract_to_nest(FILE_FORMAT_CTX *ctx);
 static int cab_remove_pkcs7(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata);
-static PKCS7 *cab_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata);
+static int cab_process_data(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata);
+static PKCS7 *cab_pkcs7_signature_new(FILE_FORMAT_CTX *ctx, BIO *hash);
 static int cab_append_pkcs7(FILE_FORMAT_CTX *ctx, BIO *outdata, PKCS7 *p7);
 static void cab_update_data_size(FILE_FORMAT_CTX *ctx, BIO *outdata, PKCS7 *p7);
 static BIO *cab_bio_free(BIO *hash, BIO *outdata);
@@ -65,8 +67,10 @@ FILE_FORMAT file_format_cab = {
     .digest_calc = cab_digest_calc,
     .verify_digests = cab_verify_digests,
     .pkcs7_extract = cab_pkcs7_extract,
+    .pkcs7_extract_to_nest = cab_pkcs7_extract_to_nest,
     .remove_pkcs7 = cab_remove_pkcs7,
-    .pkcs7_prepare = cab_pkcs7_prepare,
+    .process_data = cab_process_data,
+    .pkcs7_signature_new = cab_pkcs7_signature_new,
     .append_pkcs7 = cab_append_pkcs7,
     .update_data_size = cab_update_data_size,
     .bio_free = cab_bio_free,
@@ -402,6 +406,16 @@ static PKCS7 *cab_pkcs7_extract(FILE_FORMAT_CTX *ctx)
 }
 
 /*
+ * Extract existing signature in DER format.
+ * [in] ctx: structure holds input and output data
+ * pointer to PKCS#7 structure
+ */
+static PKCS7 *cab_pkcs7_extract_to_nest(FILE_FORMAT_CTX *ctx)
+{
+    return cab_pkcs7_extract(ctx);
+}
+
+/*
  * Remove existing signature.
  * [in, out] ctx: structure holds input and output data
  * [out] hash: message digest BIO (unused)
@@ -479,83 +493,62 @@ static int cab_remove_pkcs7(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
 }
 
 /*
- * Obtain an existing signature or create a new one.
+ * Modify specific type data and calculate a hash (message digest) of data.
  * [in, out] ctx: structure holds input and output data
  * [out] hash: message digest BIO
  * [out] outdata: outdata file BIO
- * [returns] pointer to PKCS#7 structure
+ * [returns] 1 on error or 0 on success
  */
-static PKCS7 *cab_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
+static int cab_process_data(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
 {
-    PKCS7 *cursig = NULL, *p7 = NULL;
-
     /* Strip current signature and modify header */
     if (ctx->cab_ctx->header_size == 20) {
         if (!cab_modify_header(ctx, hash, outdata))
-            return NULL; /* FAILED */
+            return 1; /* FAILED */
     } else {
         if (!cab_add_header(ctx, hash, outdata))
-            return NULL; /* FAILED */
+            return 1; /* FAILED */
     }
-    /* Obtain a current signature from previously-signed file */
-    if ((ctx->options->cmd == CMD_SIGN && ctx->options->nest)
-        || (ctx->options->cmd == CMD_ATTACH && ctx->options->nest)
-        || ctx->options->cmd == CMD_ADD) {
-        cursig = cab_pkcs7_extract(ctx);
-        if (!cursig) {
-            printf("Unable to extract existing signature\n");
-            return NULL; /* FAILED */
-        }
-        ctx->options->nested_number = nested_signatures_number_get(cursig);
-        if (ctx->options->nested_number < 0) {
-            printf("Unable to get number of nested signatures\n");
-            PKCS7_free(cursig);
-            return NULL; /* FAILED */
-        }
-        if (ctx->options->cmd == CMD_ADD)
-            p7 = cursig;
+    return 0; /* OK */
+}
+
+/*
+ * Create a new PKCS#7 signature.
+ * [in, out] ctx: structure holds input and output data
+ * [out] hash: message digest BIO
+ * [returns] pointer to PKCS#7 structure
+ */
+static PKCS7 *cab_pkcs7_signature_new(FILE_FORMAT_CTX *ctx, BIO *hash)
+{
+    ASN1_OCTET_STRING *content;
+    PKCS7 *p7 = pkcs7_create(ctx);
+
+    if (!p7) {
+        printf("Creating a new signature failed\n");
+        return NULL; /* FAILED */
     }
-    if (ctx->options->cmd == CMD_ATTACH) {
-        /* Obtain an existing PKCS#7 signature */
-        p7 = pkcs7_get_sigfile(ctx);
-        if (!p7) {
-            printf("Unable to extract valid signature\n");
-            PKCS7_free(cursig);
-            return NULL; /* FAILED */
-        }
-    } else if (ctx->options->cmd == CMD_SIGN) {
-        ASN1_OCTET_STRING *content;
-        /* Create a new PKCS#7 signature */
-        p7 = pkcs7_create(ctx);
-        if (!p7) {
-            printf("Creating a new signature failed\n");
-            return NULL; /* FAILED */
-        }
-        if (ctx->options->jp >= 0 && !cab_add_jp_attribute(p7, ctx->options->jp)) {
-            printf("Adding jp attribute failed\n");
-            PKCS7_free(p7);
-            return NULL; /* FAILED */
-        }
-        if (!add_indirect_data_object(p7)) {
-            printf("Adding SPC_INDIRECT_DATA_OBJID failed\n");
-            PKCS7_free(p7);
-            return NULL; /* FAILED */
-        }
-        content = spc_indirect_data_content_get(hash, ctx);
-        if (!content) {
-            printf("Failed to get spcIndirectDataContent\n");
-            return NULL; /* FAILED */
-        }
-        if (!sign_spc_indirect_data_content(p7, content)) {
-            printf("Failed to set signed content\n");
-            PKCS7_free(p7);
-            ASN1_OCTET_STRING_free(content);
-            return NULL; /* FAILED */
-        }
+    if (ctx->options->jp >= 0 && !cab_add_jp_attribute(p7, ctx->options->jp)) {
+        printf("Adding jp attribute failed\n");
+        PKCS7_free(p7);
+        return NULL; /* FAILED */
+    }
+    if (!add_indirect_data_object(p7)) {
+        printf("Adding SPC_INDIRECT_DATA_OBJID failed\n");
+        PKCS7_free(p7);
+        return NULL; /* FAILED */
+    }
+    content = spc_indirect_data_content_get(hash, ctx);
+    if (!content) {
+        printf("Failed to get spcIndirectDataContent\n");
+        return NULL; /* FAILED */
+    }
+    if (!sign_spc_indirect_data_content(p7, content)) {
+        printf("Failed to set signed content\n");
+        PKCS7_free(p7);
         ASN1_OCTET_STRING_free(content);
+        return NULL; /* FAILED */
     }
-    if (ctx->options->nest)
-        ctx->options->prevsig = cursig;
+    ASN1_OCTET_STRING_free(content);
     return p7;
 }
 

--- a/cab.c
+++ b/cab.c
@@ -506,6 +506,12 @@ static PKCS7 *cab_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
             printf("Unable to extract existing signature\n");
             return NULL; /* FAILED */
         }
+        ctx->options->nested_number = nested_signatures_number_get(cursig);
+        if (ctx->options->nested_number < 0) {
+            printf("Unable to get number of nested signatures\n");
+            PKCS7_free(cursig);
+            return NULL; /* FAILED */
+        }
         if (ctx->options->cmd == CMD_ADD)
             p7 = cursig;
     }

--- a/helpers.h
+++ b/helpers.h
@@ -26,6 +26,7 @@ MsCtlContent *ms_ctl_content_get(PKCS7 *p7);
 ASN1_TYPE *catalog_content_get(CatalogAuthAttr *attribute);
 SpcLink *spc_link_obsolete_get(void);
 int compare_digests(u_char *mdbuf, u_char *cmdbuf, int mdtype);
+int nested_signatures_number_get(PKCS7 *p7);
 
 /*
 Local Variables:

--- a/helpers.h
+++ b/helpers.h
@@ -9,7 +9,6 @@
 uint32_t get_file_size(const char *infile);
 char *map_file(const char *infile, const size_t size);
 void unmap_file(char *indata, const size_t size);
-PKCS7 *pkcs7_get_sigfile(FILE_FORMAT_CTX *ctx);
 PKCS7 *pkcs7_read_data(char *indata, uint32_t size);
 int data_write_pkcs7(FILE_FORMAT_CTX *ctx, BIO *outdata, PKCS7 *p7);
 PKCS7 *pkcs7_create(FILE_FORMAT_CTX *ctx);
@@ -26,7 +25,6 @@ MsCtlContent *ms_ctl_content_get(PKCS7 *p7);
 ASN1_TYPE *catalog_content_get(CatalogAuthAttr *attribute);
 SpcLink *spc_link_obsolete_get(void);
 int compare_digests(u_char *mdbuf, u_char *cmdbuf, int mdtype);
-int nested_signatures_number_get(PKCS7 *p7);
 
 /*
 Local Variables:

--- a/msi.c
+++ b/msi.c
@@ -676,6 +676,12 @@ static PKCS7 *msi_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
             PKCS7_free(cursig);
             return NULL; /* FAILED */
         }
+        ctx->options->nested_number = nested_signatures_number_get(cursig);
+        if (ctx->options->nested_number < 0) {
+            printf("Unable to get number of nested signatures\n");
+            PKCS7_free(cursig);
+            return NULL; /* FAILED */
+        }
         if (ctx->options->cmd == CMD_ADD)
             p7 = cursig;
     }

--- a/osslsigncode.h
+++ b/osslsigncode.h
@@ -266,6 +266,7 @@ typedef struct {
 #endif /* ENABLE_CURL */
     int addBlob;
     int nest;
+    int index;
     int ignore_timestamp;
     int verbose;
     int add_msi_dse;

--- a/osslsigncode.h
+++ b/osslsigncode.h
@@ -288,7 +288,6 @@ typedef struct {
     STACK_OF(X509_CRL) *crls;
     cmd_type_t cmd;
     char *indata;
-    PKCS7 *prevsig;
     char *tsa_certfile;
     char *tsa_keyfile;
     time_t tsa_time;
@@ -504,8 +503,10 @@ struct file_format_st {
     int (*verify_digests) (FILE_FORMAT_CTX *ctx, PKCS7 *p7);
     int (*verify_indirect_data) (FILE_FORMAT_CTX *ctx, SpcAttributeTypeAndOptionalValue *obj);
     PKCS7 *(*pkcs7_extract) (FILE_FORMAT_CTX *ctx);
+    PKCS7 *(*pkcs7_extract_to_nest) (FILE_FORMAT_CTX *ctx);
     int (*remove_pkcs7) (FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata);
-    PKCS7 *(*pkcs7_prepare) (FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata);
+    int (*process_data) (FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata);
+    PKCS7 *(*pkcs7_signature_new) (FILE_FORMAT_CTX *ctx, BIO *hash);
     int (*append_pkcs7) (FILE_FORMAT_CTX *ctx, BIO *outdata, PKCS7 *p7);
     void (*update_data_size) (FILE_FORMAT_CTX *data, BIO *outdata, PKCS7 *p7);
     BIO *(*bio_free) (BIO *hash, BIO *outdata);

--- a/osslsigncode.h
+++ b/osslsigncode.h
@@ -187,6 +187,7 @@
 #define PKCS9_MESSAGE_DIGEST         "1.2.840.113549.1.9.4"
 #define PKCS9_SIGNING_TIME           "1.2.840.113549.1.9.5"
 #define PKCS9_COUNTER_SIGNATURE      "1.2.840.113549.1.9.6"
+#define PKCS9_SEQUENCE_NUMBER        "1.2.840.113549.1.9.25.4"
 
 /* WIN_CERTIFICATE structure declared in Wintrust.h */
 #define WIN_CERT_REVISION_2_0           0x0200
@@ -291,6 +292,7 @@ typedef struct {
     char *tsa_certfile;
     char *tsa_keyfile;
     time_t tsa_time;
+    int nested_number;
 } GLOBAL_OPTIONS;
 
 /*

--- a/pe.c
+++ b/pe.c
@@ -423,6 +423,12 @@ static PKCS7 *pe_pkcs7_prepare(FILE_FORMAT_CTX *ctx, BIO *hash, BIO *outdata)
             printf("Unable to extract existing signature\n");
             return NULL; /* FAILED */
         }
+        ctx->options->nested_number = nested_signatures_number_get(cursig);
+        if (ctx->options->nested_number < 0) {
+            printf("Unable to get number of nested signatures\n");
+            PKCS7_free(cursig);
+            return NULL; /* FAILED */
+        }
         if (ctx->options->cmd == CMD_ADD)
             p7 = cursig;
     }


### PR DESCRIPTION
- fixed setting unauthenticated attributes (Countersignature,
  Unauthenticated Data Blob) in a nested signature
- added support for verifying the signature at a certain position ("-index" option)
- added support for adding unauthenticated attributes to the signature
  at a certain position ("-index" option)
- PKCS9_SEQUENCE_NUMBER authenticated attribute support
- simplify code

Close #338