### PR TITLE
Fix python 3 compatibility in server_http.py

### DIFF
--- a/tests/server_http.py
+++ b/tests/server_http.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from urllib.parse import urlparse
 from http.server import SimpleHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
 
 RESULT_PATH = os.getcwd()
 FILES_PATH = os.path.join(RESULT_PATH, "./Testing/files/")
@@ -27,6 +28,8 @@ OPENSSL_TS = ["openssl", "ts",
     "-queryfile", REQUEST,
     "-out", RESPONS]
 
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
 
 class RequestHandler(SimpleHTTPRequestHandler):
     """Handle the HTTP POST request that arrive at the server"""
@@ -96,7 +99,7 @@ class HttpServerThread():
 
     def start_server(self, port) -> (int):
         """Starting HTTP server on 127.0.0.1 and a random available port for binding"""
-        self.server = HTTPServer(('127.0.0.1', port), RequestHandler)
+        self.server = ThreadingHTTPServer(('127.0.0.1', port), RequestHandler)
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()
         hostname, port = self.server.server_address[:2]

--- a/tests/server_http.py
+++ b/tests/server_http.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import threading
 from urllib.parse import urlparse
-from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from http.server import SimpleHTTPRequestHandler, HTTPServer
 
 RESULT_PATH = os.getcwd()
 FILES_PATH = os.path.join(RESULT_PATH, "./Testing/files/")
@@ -96,7 +96,7 @@ class HttpServerThread():
 
     def start_server(self, port) -> (int):
         """Starting HTTP server on 127.0.0.1 and a random available port for binding"""
-        self.server = ThreadingHTTPServer(('127.0.0.1', port), RequestHandler)
+        self.server = HTTPServer(('127.0.0.1', port), RequestHandler)
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()
         hostname, port = self.server.server_address[:2]


### PR DESCRIPTION
Building osslsigncode fails on systems with older versions of Python 3. This is due to the server_http.py script, that runs as a part of the test procedure. It imports the `ThreadingHTTPServer`-module which was added to Python in version 3.7.

Replacing `ThreadingHTTPServer` with a plain `HTTPServer` allows us to build for older versions of Python 3 without excluding the tests from the build.