### PR TITLE
Add '-login' option to force a login to PKCS11 engine

### DIFF
--- a/osslsigncode.h
+++ b/osslsigncode.h
@@ -256,6 +256,7 @@ typedef struct {
     char *p11engine;
     char *p11module;
     char *p11cert;
+    int login;
 #endif /* OPENSSL_NO_ENGINE */
     int askpass;
     char *readpass;


### PR DESCRIPTION
When trying to use AWS CloudHSM's PCKS11 provider with osslsigncode, I found that providing the token pin via the `-pass` option failed, while entering it interactively when prompted by openssl-pkcs11 (from libp11) engine worked correctly.

After some debugging, I found that forcing an early login to the PKCS11 engine allowed the `-pass` option to work reliably. This adds a new `-login` option to FORCE_LOGIN for PKCS11 providers.