### PR TITLE
tests: add import for python-crypotgraphy >= 43.0.0

### DIFF
--- a/tests/make_certificates.py
+++ b/tests/make_certificates.py
@@ -10,6 +10,8 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+import cryptography.hazmat.primitives.serialization.pkcs12
+
 RESULT_PATH = os.getcwd()
 CERTS_PATH = os.path.join(RESULT_PATH, "./Testing/certs/")
 


### PR DESCRIPTION
write_pkcs12_container method raises following error message with `python-cryptography-43.0.0`:
```
Error: module 'cryptography.hazmat.primitives.serialization' has no attribute 'pkcs12'
```
Explicit import of the `pkcs12` module resolves the issue.

---
I am not sure what exactly causes the issue, I couldn't spot it in `python-cryptography` `42.0.8..43.0.0` diff.