### PR TITLE
Fix capitalization for `ws2_32.lib`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ target_link_libraries(osslsigncode PRIVATE ${ZLIB_LIBRARIES})
 
 if(NOT UNIX)
 # https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-shutdown
-target_link_libraries(osslsigncode PRIVATE Ws2_32.lib crypt32.lib)
+target_link_libraries(osslsigncode PRIVATE ws2_32.lib crypt32.lib)
 endif(NOT UNIX)
 
 # add paths to linker search and installed rpath


### PR DESCRIPTION
Windows and MacOS are both case-insensitive, and hence the issue of wrong capitalisation may not have surfaced. 

I am forming a recipe for cross-compilation for the Julia BinarBuilder environment, which uses Linux x86_64 as the host system. However, as it uses a sensitive filesystem, I hit a linking error that could only be fixed by changing the capitalisation of `Ws2_32.lib` to lowercase. 

More on that can be found in the pull request:
https://github.com/JuliaPackaging/Yggdrasil/pull/10950