### PR TITLE
Suppress compiler warnings with OpenSSL < 3.0 and fix engine-less builds

### DIFF
--- a/appx.c
+++ b/appx.c
@@ -873,11 +873,18 @@ static uint8_t *appx_calc_zip_central_directory_hash(ZIP_FILE *zip, const EVP_MD
     u_char *mdbuf = NULL;
     BIO *bhash = BIO_new(BIO_f_md());
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(bhash);
         return NULL; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     if (!appx_write_central_directory(bhash, zip, 1, cdOffset)) {
         fprintf(stderr, "Unable to write central directory\n");
@@ -1000,11 +1007,18 @@ static uint8_t *appx_calc_zip_data_hash(uint64_t *cdOffset, ZIP_FILE *zip, const
     BIO *bhash = BIO_new(BIO_f_md());
     uint64_t noEntries = 0;
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(bhash);
         return NULL; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     *cdOffset = 0;
     for (entry = zip->centralDirectoryHead; entry != NULL; entry = entry->next) {
@@ -1758,12 +1772,19 @@ static u_char *zipCalcDigest(ZIP_FILE *zip, const char *fileName, const EVP_MD *
         return NULL; /* FAILED */
     }
     bhash = BIO_new(BIO_f_md());
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         OPENSSL_free(data);
         BIO_free_all(bhash);
         return NULL; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     if (!bio_hash_data(bhash, (char *)data, 0, dataSize)) {
         OPENSSL_free(data);

--- a/cab.c
+++ b/cab.c
@@ -205,11 +205,18 @@ static u_char *cab_digest_calc(FILE_FORMAT_CTX *ctx, const EVP_MD *md)
     u_char *mdbuf = NULL;
     BIO *bhash = BIO_new(BIO_f_md());
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(bhash);
         return 0;  /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
 
     /* u1 signature[4] 4643534D MSCF: 0-3 */

--- a/helpers.c
+++ b/helpers.c
@@ -777,6 +777,15 @@ static int X509_compare(const X509 *const *a, const X509 *const *b)
     size_t a_len, b_len;
     int ret;
 
+#if OPENSSL_VERSION_NUMBER<0x30000000L
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#endif
+#endif /* OPENSSL_VERSION_NUMBER<0x30000000L */
     a_len = (size_t)i2d_X509(*a, NULL);
     a_tmp = a_data = OPENSSL_malloc(a_len);
     i2d_X509(*a, &a_tmp);
@@ -784,6 +793,13 @@ static int X509_compare(const X509 *const *a, const X509 *const *b)
     b_len = (size_t)i2d_X509(*b, NULL);
     b_tmp = b_data = OPENSSL_malloc(b_len);
     i2d_X509(*b, &b_tmp);
+#if OPENSSL_VERSION_NUMBER<0x30000000L
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#endif /* OPENSSL_VERSION_NUMBER<0x30000000L */
 
     ret = memcmp(a_data, b_data, MIN(a_len, b_len));
     OPENSSL_free(a_data);

--- a/msi.c
+++ b/msi.c
@@ -373,11 +373,18 @@ static u_char *msi_digest_calc(FILE_FORMAT_CTX *ctx, const EVP_MD *md)
     u_char *mdbuf = NULL;
     BIO *bhash = BIO_new(BIO_f_md());
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(bhash);
         return NULL;  /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     if (!bio_hash_data(bhash, ctx->options->indata, 0, ctx->msi_ctx->fileend)) {
         fprintf(stderr, "Unable to calculate digest\n");
@@ -426,11 +433,18 @@ static int msi_verify_digests(FILE_FORMAT_CTX *ctx, PKCS7 *p7)
     printf("Message digest algorithm         : %s\n", OBJ_nid2sn(mdtype));
     md = EVP_get_digestbynid(mdtype);
     hash = BIO_new(BIO_f_md());
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(hash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(hash);
         return 0; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(hash, BIO_new(BIO_s_null()));
     if (ctx->msi_ctx->p_msiex) {
         BIO *prehash = BIO_new(BIO_f_md());
@@ -440,12 +454,19 @@ static int msi_verify_digests(FILE_FORMAT_CTX *ctx, PKCS7 *p7)
             BIO_free_all(prehash);
             return 0; /* FAILED */
         }
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
         if (!BIO_set_md(prehash, md)) {
             fprintf(stderr, "Unable to set the message digest of BIO\n");
             BIO_free_all(hash);
             BIO_free_all(prehash);
             return 0; /* FAILED */
         }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         BIO_push(prehash, BIO_new(BIO_s_null()));
 
         print_hash("Current MsiDigitalSignatureEx    ", "", (u_char *)ctx->msi_ctx->p_msiex,
@@ -2298,11 +2319,18 @@ static int msi_calc_MsiDigitalSignatureEx(FILE_FORMAT_CTX *ctx, BIO *hash)
     size_t written;
     BIO *prehash = BIO_new(BIO_f_md());
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(prehash, ctx->options->md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(prehash);
         return 0; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(prehash, BIO_new(BIO_s_null()));
 
     if (!msi_prehash_dir(ctx->msi_ctx->dirent, prehash, 1)) {

--- a/osslsigncode.c
+++ b/osslsigncode.c
@@ -303,10 +303,17 @@ static BIO *bio_encode_rfc3161_request(PKCS7 *p7, const EVP_MD *md)
         goto out;
 
     bhash = BIO_new(BIO_f_md());
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         goto out;
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     BIO_write(bhash, si->enc_digest->data, si->enc_digest->length);
     BIO_gets(bhash, (char*)mdbuf, EVP_MD_size(md));
@@ -1817,10 +1824,17 @@ static int trusted_cert(X509 *cert, int error) {
     const EVP_MD *md = EVP_get_digestbynid(NID_sha256);
     BIO *bhash = BIO_new(BIO_f_md());
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         BIO_free_all(bhash);
         return 0; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     len = i2d_X509(cert, NULL);
     p = OPENSSL_malloc((size_t)len);
@@ -2173,12 +2187,19 @@ static int verify_timestamp_token(PKCS7 *p7, CMS_ContentInfo *timestamp)
 
             /* compute a hash from the encrypted message digest value of the file */
             bhash = BIO_new(BIO_f_md());
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
             if (!BIO_set_md(bhash, md)) {
                 fprintf(stderr, "Unable to set the message digest of BIO\n");
                 BIO_free_all(bhash);
                 TS_TST_INFO_free(token);
                 return 0; /* FAILED */
             }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             BIO_push(bhash, BIO_new(BIO_s_null()));
             BIO_write(bhash, si->enc_digest->data, si->enc_digest->length);
             BIO_gets(bhash, (char*)mdbuf, EVP_MD_size(md));
@@ -2531,12 +2552,19 @@ static int verify_leaf_hash(X509 *cert, const char *leafhash)
 
     /* compute the leaf certificate hash */
     bhash = BIO_new(BIO_f_md());
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(bhash);
         OPENSSL_free(mdbuf);
         return 0; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     certlen = (size_t)i2d_X509(cert, NULL);
     certbuf = OPENSSL_malloc(certlen);
@@ -3346,7 +3374,23 @@ static int PKCS7_compare(const PKCS7 *const *a, const PKCS7 *const *b)
     long index_a, index_b;
     int ret = 0;
 
+#if OPENSSL_VERSION_NUMBER<0x30000000L
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#endif
+#endif /* OPENSSL_VERSION_NUMBER<0x30000000L */
     p7_a = PKCS7_dup(*a);
+#if OPENSSL_VERSION_NUMBER<0x30000000L
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#endif /* OPENSSL_VERSION_NUMBER>=0x30000000L */
     if (!p7_a)
         goto out;
     signer_info = PKCS7_get_signer_info(p7_a);
@@ -3358,7 +3402,23 @@ static int PKCS7_compare(const PKCS7 *const *a, const PKCS7 *const *b)
     time_a = asn1_time_get_si_time(si);
     index_a = get_sequence_number(si);
 
+#if OPENSSL_VERSION_NUMBER<0x30000000L
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
+#endif
+#endif /* OPENSSL_VERSION_NUMBER<0x30000000L */
     p7_b = PKCS7_dup(*b);
+#if OPENSSL_VERSION_NUMBER<0x30000000L
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#endif /* OPENSSL_VERSION_NUMBER>=0x30000000L */
     if (!p7_b)
         goto out;
     signer_info = PKCS7_get_signer_info(p7_b);
@@ -5011,9 +5071,16 @@ int main(int argc, char **argv)
     if (options.cmd != CMD_VERIFY) {
         /* Create message digest BIO */
         hash = BIO_new(BIO_f_md());
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
         if (!BIO_set_md(hash, options.md)) {
             DO_EXIT_0("Unable to set the message digest of BIO\n");
         }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         /* Create outdata file */
         outdata = BIO_new_file(options.outfile, "w+bx");
         if (!outdata && errno != EEXIST)

--- a/osslsigncode.c
+++ b/osslsigncode.c
@@ -4242,15 +4242,19 @@ static int read_crypto_params(GLOBAL_OPTIONS *options)
     else if (options->p11engine) {
         if(!engine_load(options))
             goto out;
+    }
 #endif /* OPENSSL_NO_ENGINE */
-    } else if (options->p11module) {
+    else if (options->p11module) {
 #if OPENSSL_VERSION_NUMBER>=0x30000000L
         /* Try to load PKCS#11 provider first */
         if ((options->provider && provider_load(options->provider)) || provider_load("pkcs11prov")) {
             load_objects_from_store(options->keyfile, options->pass, &options->pkey, NULL, NULL);
             load_objects_from_store(options->p11cert, options->pass, NULL, options->certs, NULL);
-        } else
+        }
 #endif /* OPENSSL_VERSION_NUMBER>=0x30000000L */
+#if !defined(OPENSSL_NO_ENGINE) && OPENSSL_VERSION_NUMBER>=0x30000000L
+        else
+#endif /* !defined(OPENSSL_NO_ENGINE) || OPENSSL_VERSION_NUMBER>=0x30000000L */
 #ifndef OPENSSL_NO_ENGINE
             /* try to find and load libp11 'pkcs11' engine */
             if (!engine_load(options))
@@ -4280,9 +4284,9 @@ static int read_crypto_params(GLOBAL_OPTIONS *options)
     if (sk_X509_num(options->certs) == 0 && !read_pkcs7_certfile(options)) {
         return 0; /* FAILED */
     }
-#if !defined(OPENSSL_NO_ENGINE) || OPENSSL_VERSION_NUMBER>=0x30000000L
+#if !defined(OPENSSL_NO_ENGINE) || OPENSSL_VERSION_NUMBER<0x1010108f
 out:
-#endif /* !defined(OPENSSL_NO_ENGINE) || OPENSSL_VERSION_NUMBER>=0x30000000L */
+#endif /* !defined(OPENSSL_NO_ENGINE) || OPENSSL_VERSION_NUMBER<0x1010108f */
     return (options->pkey && sk_X509_num(options->certs) > 0) ? 1 : 0;
 }
 

--- a/osslsigncode.h
+++ b/osslsigncode.h
@@ -268,11 +268,13 @@ typedef struct {
     int output_pkcs7;
 #ifndef OPENSSL_NO_ENGINE
     char *p11engine;
+    STACK_OF(EngineControl) *engine_ctrls;
+    int login;
+#endif /* OPENSSL_NO_ENGINE */
+#if !defined(OPENSSL_NO_ENGINE) || OPENSSL_VERSION_NUMBER>=0x30000000L
     char *p11module;
     char *p11cert;
-    int login;
-    STACK_OF(EngineControl) *engine_ctrls;
-#endif /* OPENSSL_NO_ENGINE */
+#endif /* !defined(OPENSSL_NO_ENGINE) || OPENSSL_VERSION_NUMBER>=0x30000000L */
     int askpass;
     char *readpass;
     char *pass;

--- a/pe.c
+++ b/pe.c
@@ -779,11 +779,18 @@ static BIO *pe_digest_calc_bio(FILE_FORMAT_CTX *ctx, const EVP_MD *md)
     uint32_t idx = 0, fileend;
     BIO *bhash = BIO_new(BIO_f_md());
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(bhash);
         return 0; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     if (ctx->pe_ctx->sigpos)
         fileend = ctx->pe_ctx->sigpos;
@@ -958,11 +965,18 @@ static u_char *pe_page_hash_calc(int *rphlen, FILE_FORMAT_CTX *ctx, int phtype)
     phlen = pphlen * (3 + (int)nsections + (int)(ctx->pe_ctx->fileend / pagesize));
 
     bhash = BIO_new(BIO_f_md());
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(bhash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(bhash);
         return NULL;  /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(bhash, BIO_new(BIO_s_null()));
     if (!BIO_write_ex(bhash, ctx->options->indata, ctx->pe_ctx->header_size + 88, &written)
         || written != ctx->pe_ctx->header_size + 88) {
@@ -1005,6 +1019,10 @@ static u_char *pe_page_hash_calc(int *rphlen, FILE_FORMAT_CTX *ctx, int phtype)
         for (l=0; l<rs; l+=pagesize, pi++) {
             PUT_UINT32_LE(ro + l, res + pi*pphlen);
             bhash = BIO_new(BIO_f_md());
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
             if (!BIO_set_md(bhash, md)) {
                 fprintf(stderr, "Unable to set the message digest of BIO\n");
                 BIO_free_all(bhash);
@@ -1012,6 +1030,9 @@ static u_char *pe_page_hash_calc(int *rphlen, FILE_FORMAT_CTX *ctx, int phtype)
                 OPENSSL_free(res);
                 return NULL;  /* FAILED */
             }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             BIO_push(bhash, BIO_new(BIO_s_null()));
             if (rs - l < pagesize) {
                 if (!BIO_write_ex(bhash, ctx->options->indata + ro + l, rs - l, &written)

--- a/script.c
+++ b/script.c
@@ -242,11 +242,18 @@ static u_char *script_digest_calc(FILE_FORMAT_CTX *ctx, const EVP_MD *md)
     u_char *mdbuf;
     BIO *hash = BIO_new(BIO_f_md());
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(hash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(hash);
         return NULL; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(hash, BIO_new(BIO_s_null()));
     if (!script_write_bio(hash, ctx->options->indata, ctx->script_ctx->fileend)) {
         BIO_free_all(hash);
@@ -782,12 +789,18 @@ static BIO *script_digest_calc_bio(FILE_FORMAT_CTX *ctx, const EVP_MD *md)
         fileend = ctx->script_ctx->sigpos;
     else
         fileend = ctx->script_ctx->fileend;
-
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
     if (!BIO_set_md(hash, md)) {
         fprintf(stderr, "Unable to set the message digest of BIO\n");
         BIO_free_all(hash);
         return NULL; /* FAILED */
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     BIO_push(hash, BIO_new(BIO_s_null()));
     if (!script_digest_convert(hash, ctx, fileend)) {
         fprintf(stderr, "Unable calc a message digest value\n");


### PR DESCRIPTION
This PR adds conditional diagnostic pragmas to locally suppress `-Wcast-qual` and` -Wdiscarded-qualifiers` warnings triggered by legacy OpenSSL APIs (`BIO_set_md`, `PKCS7_dup`, `i2d_X509`) which discard `const` qualifiers. These warnings are harmless, as OpenSSL does not modify the data. Suppressing them locally avoids build noise while preserving correctness and portability.

Additionally, this fixes build failures with OpenSSL ≥ 3.0 when engines are disabled via `OPENSSL_NO_ENGINE` or `OPENSSL_NO_DEPRECATED`.
Fixes #430.