### PR TITLE
cmake: drop USE_WIN32 define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,6 @@ set(PACKAGE_BUGREPORT "Michal.Trojnara@stunnel.org")
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
-if(WIN32)
-    add_definitions(-DUSE_WIN32)
-endif()
-
 # load CMake library modules
 include(FindOpenSSL)
 if(OPENSSL_VERSION VERSION_LESS "1.1.1")


### PR DESCRIPTION
This was added in #423, but it's only use was then removed in #435.