### PR TITLE
Improve UTF-8 handling for certificate names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 - improved unauthenticated blob support (thanks to Asger Hautop Drewsen)
 - fixed support for multiple signerInfo contentType OIDs (CTL and Authenticode)
 - fixed tests for python-cryptography >= 43.0.0
+- improved UTF-8 handling for certificate subjects and issuers;
+  missing names now print as "N/A"
 
 ### 2.9 (2024.06.29)
 


### PR DESCRIPTION
- add helper to convert `X509_NAME` to UTF‑8
- print subject and issuer names using the helper
- handle `NULL` certificate names gracefully by returning `"N/A"`
- document improved UTF‑8 certificate handling